### PR TITLE
Discord: support curl as alternative to wget

### DIFF
--- a/discord/README.md
+++ b/discord/README.md
@@ -13,11 +13,13 @@ A simple Discord installer and updater for Linux systems.
 
 ## Requirements
 - Linux-based operating system
-- wget for downloading files
+- wget or curl for downloading files
 - sudo privileges for Discord installation
 
 ## Installation
+
 To set up Butter Discord:
+
 ```bash
 # Clone repository
 git clone https://github.com/drewgrif/butterscripts.git
@@ -26,23 +28,19 @@ git clone https://github.com/drewgrif/butterscripts.git
 cd butterscripts/discord
 
 # Make executable
-chmod +x butterdis.sh
-
-# Setup script in your environment
-./butterdis.sh setup
-
+chmod +x butterdis_simple.sh
 ```
 
 ## Usage
 ```bash
 # Install or update Discord
-butter-discord
+./butterdis_simple.sh 
 
 # Uninstall Discord
-butter-discord uninstall
+./butterdis_simple.sh uninstall
 
 # Show help information
-butter-discord help
+./butterdis_simple.sh help
 ```
 
 ## How It Works

--- a/discord/butterdis_simple.sh
+++ b/discord/butterdis_simple.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+set -e
+
 # Define variables
 DISCORD_DIR="/opt/Discord"
 DISCORD_BIN="/usr/bin/Discord"
 DESKTOP_FILE="/usr/share/applications/discord.desktop"
+TAR_URL="https://discord.com/api/download?platform=linux&format=tar.gz"
 TAR_FILE="discord.tar.gz"
 
 # Function to install or update Discord
@@ -12,7 +15,14 @@ install_discord() {
     
     # Download latest Discord
     echo "Downloading latest Discord..."
-    wget "https://discord.com/api/download?platform=linux&format=tar.gz" -O "$TAR_FILE"
+    if command -v wget >/dev/null 2>&1; then
+        wget "$TAR_URL" -O "$TAR_FILE"
+    elif command -v curl >/dev/null 2>&1; then
+        curl -L "$TAR_URL" -o "$TAR_FILE"
+    else
+        echo "Error: Neither wget nor curl is installed." >&2
+        exit 1
+    fi
     
     # Remove old installation if exists
     if [ -d "$DISCORD_DIR" ] || [ -f "$DISCORD_BIN" ]; then


### PR DESCRIPTION
## Problem

On my machine, `wget` wasn’t installed since I exclusively use `curl`. The script failed silently, continuing through the rest of the install process even though the download step failed. The output was misleading:

```txt
butterscripts/discord::main()  ./butterdis_simple.sh
Installing/updating Discord...
Downloading latest Discord...
./butterdis_simple.sh: line 15: wget: command not found
Extracting files...
tar: discord.tar.gz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
rm: cannot remove 'discord.tar.gz': No such file or directory
Creating symlink...
Creating desktop entry...
Discord installation complete.
butterscripts/discord::main()  Discord
-bash: /usr/bin/Discord: No such file or directory
```

I tunnel-visioned on the “installation complete” message and assumed it had succeeded, only to find Discord wasn't installed at all.

## Solution

Added `set -e` so the script exits immediately on failure. Also, added `curl` as a fallback when `wget` is unavailable.

## Gratitude

Just wanted to say thanks — I discovered your script after watching TheLinuxCast's [*Is Void Linux Good? – With Jake from @JakeLinux*](https://youtu.be/oieiYvQ9Rxo?si=3aA3e9TZnBl4PxBH). I had recently installed Void Linux and gave up on getting Discord working... until you mentioned your favorite script. Huge help!